### PR TITLE
Add hex packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ _*
 .erlang.cookie
 ebin
 log
+doc
 erl_crash.dump
 .rebar
 logs

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,7 @@ test:
 dialyzer:
 	@$(REBAR) as dialyzer dialyzer
 
+hex-build:
+	@$(REBAR) hex build
+
 .PHONY: all compile clean test dialyzer

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ compile:
 
 clean:
 	@$(REBAR) clean
+	@rm -rf doc
 
 test:
 	@$(REBAR) eunit

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ pact-erlang
 
 An erlang library for contract testing using pact ffi and generating consumer pacts 
 
+Docs: https://hexdocs.pm/pact_erlang/readme.html
+
 Build
 -----
 
@@ -12,10 +14,7 @@ Build
 Add pact-erlang as a dependency in your application
 ---------------------------------------------------
 ```
-{erl_opts, [debug_info]}.
-{deps,[
-    {pact_erlang, ".*", {git, "https://github.com/silverblaze404/pact_erlang.git", {branch, "develop"}}}
-]}.
+{deps, [pact_erlang]}.
 ```
 
 Usage

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
+{project_plugins, [rebar3_hex, rebar3_ex_doc]}.
 {erl_opts, [debug_info]}.
 {deps, []}.
-
 
 {pre_hooks, [
     {"(linux|darwin|solaris)", compile, "make --no-print-directory -C c_src"},
@@ -10,3 +10,11 @@
     {"(linux|darwin|solaris)", clean, "make --no-print-directory -C c_src clean"},
     {"(freebsd)", clean, "gmake -C c_src clean"}
 ]}.
+
+{ex_doc, [
+    {source_url, <<"https://github.com/greyorange-labs/pact-erlang">>},
+    {extras, [<<"README.md">>, <<"LICENSE">>]},
+    {main, <<"readme">>}
+]}.
+
+{hex, [{doc, ex_doc}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -13,8 +13,11 @@
 
 {ex_doc, [
     {source_url, <<"https://github.com/greyorange-labs/pact-erlang">>},
+    {homepage_url, <<"https://hexdocs.pm/pact_erlang">>},
     {extras, [<<"README.md">>, <<"LICENSE">>]},
-    {main, <<"readme">>}
+    {main, <<"readme">>},
+    {prefix_ref_vsn_with_v, false},
+    {api_reference, false}
 ]}.
 
 {hex, [{doc, ex_doc}]}.

--- a/src/pact_erlang.app.src
+++ b/src/pact_erlang.app.src
@@ -1,14 +1,15 @@
 {application, pact_erlang,
- [{description, "An OTP library"},
-  {vsn, "0.1.0"},
+ [{description, "Erlang wrapper for Pact. Pact is a contract testing framework for HTTP APIs and non-HTTP asynchronous messaging systems."},
+  {vsn, "git"},
+  {modules, []},
   {registered, []},
   {applications,
    [kernel,
     stdlib
    ]},
-  {env,[]},
-  {modules, []},
 
   {licenses, ["Apache-2.0"]},
-  {links, []}
+  {links, [{"GitHub", "https://github.com/greyorange-labs/pact-erlang"}]},
+  {build_tools, ["rebar3"]},
+  {files, ["src", "c_src", "rebar.config", "README.md","LICENSE", "Makefile"]}
  ]}.


### PR DESCRIPTION
Actual packaging and upload has to be done manually for now.

Manual steps:
1. Setup [rebar3 hex plugin](https://hexdocs.pm/rebar3_hex/readme.html)
2. Add a new git tag
3. `rebar3 hex build`
4. `rebar3 hex publish`