### PR TITLE
Include support for linux aarch64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Support for missing linux aarch64 architecture
+
 
 ## [0.2.1] - 2023-08-17
 

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -17,6 +17,9 @@ ifeq ($(UNAME),Linux)
     ifeq ($(ARCHITECTURE), arm64)
         PACT_FILE_NAME := libpact_ffi-linux-aarch64.a
     endif
+	ifeq ($(ARCHITECTURE), aarch64)
+        PACT_FILE_NAME := libpact_ffi-linux-aarch64.a
+    endif
     ifeq ($(ARCHITECTURE), x86_64)
         PACT_FILE_NAME := libpact_ffi-linux-x86_64.a
     endif


### PR DESCRIPTION
# Description

Fixed missing support for linux aarch64 architecture

# Checklist:

- [ ] I have ensured that all new code is covered by tests
- [x] I have run `make format` to format the code according to guidelines
- [x] I have documented any new functions introduced
- [x] I have updated the changelog in accordance with https://keepachangelog.com/en/1.1.0/
- [x] I have updated the README, if required
