### PR TITLE
Feat/alpine musl support

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -21,8 +21,6 @@ endif
 
 ifeq ($(UNAME),Linux)
     CFLAGS := -O2 -Wmissing-prototypes -Wall -shared -o
-    # Detect the target libc from the compiler triple (e.g.
-    # x86_64-alpine-linux-musl -> musl) so we fetch a matching variant.
     LIBC := $(shell $(CC) -dumpmachine 2>/dev/null | grep -q musl && echo musl || echo glibc)
     ifeq ($(LIBC), musl)
         LIBC_SUFFIX := -musl

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -12,39 +12,26 @@ PACT_FFI_VERSION  := 0.4.27
 PACT_FFI_BASE_URL := https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v$(PACT_FFI_VERSION)
 PACT_H_URL        := $(PACT_FFI_BASE_URL)/pact.h
 
+# Normalise the machine arch to pact's naming (arm64/aarch64 -> aarch64).
+ifeq ($(ARCHITECTURE), x86_64)
+    PACT_ARCH := x86_64
+else
+    PACT_ARCH := aarch64
+endif
+
 ifeq ($(UNAME),Linux)
     CFLAGS := -O2 -Wmissing-prototypes -Wall -shared -o
+    # Detect the target libc from the compiler triple (e.g.
+    # x86_64-alpine-linux-musl -> musl) so we fetch a matching variant.
     LIBC := $(shell $(CC) -dumpmachine 2>/dev/null | grep -q musl && echo musl || echo glibc)
-    ifeq ($(ARCHITECTURE), arm64)
-        ifeq ($(LIBC), musl)
-            PACT_FILE_NAME := libpact_ffi-linux-aarch64-musl.a
-        else
-            PACT_FILE_NAME := libpact_ffi-linux-aarch64.a
-        endif
+    ifeq ($(LIBC), musl)
+        LIBC_SUFFIX := -musl
     endif
-    ifeq ($(ARCHITECTURE), aarch64)
-        ifeq ($(LIBC), musl)
-            PACT_FILE_NAME := libpact_ffi-linux-aarch64-musl.a
-        else
-            PACT_FILE_NAME := libpact_ffi-linux-aarch64.a
-        endif
-    endif
-    ifeq ($(ARCHITECTURE), x86_64)
-        ifeq ($(LIBC), musl)
-            PACT_FILE_NAME := libpact_ffi-linux-x86_64-musl.a
-        else
-            PACT_FILE_NAME := libpact_ffi-linux-x86_64.a
-        endif
-    endif
+    PACT_FILE_NAME := libpact_ffi-linux-$(PACT_ARCH)$(LIBC_SUFFIX).a
 endif
 ifeq ($(UNAME),Darwin)
     CFLAGS := -undefined dynamic_lookup -shared -o
-    ifeq ($(ARCHITECTURE), arm64)
-        PACT_FILE_NAME := libpact_ffi-macos-aarch64.a
-    endif
-    ifeq ($(ARCHITECTURE), x86_64)
-        PACT_FILE_NAME := libpact_ffi-macos-x86_64.a
-    endif
+    PACT_FILE_NAME := libpact_ffi-macos-$(PACT_ARCH).a
 endif
 PACT_FFI_URL := $(PACT_FFI_BASE_URL)/$(PACT_FILE_NAME).gz
 

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -12,7 +12,6 @@ PACT_FFI_VERSION  := 0.4.27
 PACT_FFI_BASE_URL := https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v$(PACT_FFI_VERSION)
 PACT_H_URL        := $(PACT_FFI_BASE_URL)/pact.h
 
-# Normalise the machine arch to pact's naming (arm64/aarch64 -> aarch64).
 ifeq ($(ARCHITECTURE), x86_64)
     PACT_ARCH := x86_64
 else

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -14,14 +14,27 @@ PACT_H_URL        := $(PACT_FFI_BASE_URL)/pact.h
 
 ifeq ($(UNAME),Linux)
     CFLAGS := -O2 -Wmissing-prototypes -Wall -shared -o
+    LIBC := $(shell ldd --version 2>&1 | head -1 | grep -qi musl && echo musl || echo glibc)
     ifeq ($(ARCHITECTURE), arm64)
-        PACT_FILE_NAME := libpact_ffi-linux-aarch64.a
+        ifeq ($(LIBC), musl)
+            PACT_FILE_NAME := libpact_ffi-linux-aarch64-musl.a
+        else
+            PACT_FILE_NAME := libpact_ffi-linux-aarch64.a
+        endif
     endif
-	ifeq ($(ARCHITECTURE), aarch64)
-        PACT_FILE_NAME := libpact_ffi-linux-aarch64.a
+    ifeq ($(ARCHITECTURE), aarch64)
+        ifeq ($(LIBC), musl)
+            PACT_FILE_NAME := libpact_ffi-linux-aarch64-musl.a
+        else
+            PACT_FILE_NAME := libpact_ffi-linux-aarch64.a
+        endif
     endif
     ifeq ($(ARCHITECTURE), x86_64)
-        PACT_FILE_NAME := libpact_ffi-linux-x86_64.a
+        ifeq ($(LIBC), musl)
+            PACT_FILE_NAME := libpact_ffi-linux-x86_64-musl.a
+        else
+            PACT_FILE_NAME := libpact_ffi-linux-x86_64.a
+        endif
     endif
 endif
 ifeq ($(UNAME),Darwin)

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -14,7 +14,7 @@ PACT_H_URL        := $(PACT_FFI_BASE_URL)/pact.h
 
 ifeq ($(UNAME),Linux)
     CFLAGS := -O2 -Wmissing-prototypes -Wall -shared -o
-    LIBC := $(shell ldd --version 2>&1 | head -1 | grep -qi musl && echo musl || echo glibc)
+    LIBC := $(shell $(CC) -dumpmachine 2>/dev/null | grep -q musl && echo musl || echo glibc)
     ifeq ($(ARCHITECTURE), arm64)
         ifeq ($(LIBC), musl)
             PACT_FILE_NAME := libpact_ffi-linux-aarch64-musl.a


### PR DESCRIPTION
# Add Alpine/musl Linux support

## Summary

The build currently only fetches the glibc variant of the precompiled `libpact_ffi` static library on Linux. On Alpine-based images (musl libc), the resulting `libpact_ffi.so` NIF fails to load at runtime:

```
Failed to load NIF library: 'Error loading shared library ld-linux-x86-64.so.2:
No such file or directory (needed by .../priv/libpact_ffi.so)'
```

This happens because the glibc static library embeds the glibc dynamic linker (`ld-linux-x86-64.so.2`) as the ELF interpreter, which doesn't exist on musl systems.

The `pact-foundation/pact-reference` releases already publish dedicated musl builds:

- `libpact_ffi-linux-x86_64-musl.a`
- `libpact_ffi-linux-aarch64-musl.a`

This PR detects musl at build time and selects the correct precompiled library, so the same `make` works transparently on both Debian/Ubuntu (glibc) and Alpine (musl).

## Changes

- Detect libc using the compiler's target triple via `$(CC) -dumpmachine` (e.g. `x86_64-alpine-linux-musl` → musl, `x86_64-linux-gnu` → glibc). This reflects what the compiler will actually link against, rather than relying on parsing `ldd --version`.
- Normalise the machine arch into a single `PACT_ARCH` (`arm64`/`aarch64` → `aarch64`) and apply `-musl` as a single `LIBC_SUFFIX`, so the library name is built in one line instead of a nested musl/glibc branch per arch. The Darwin block reuses `PACT_ARCH` too.
- Behaviour on glibc systems is unchanged (same library names as before).

> Resolved library names are unchanged for every existing OS/arch/libc combination. The only net difference is that an unrecognised arch now falls through to `aarch64` instead of producing an empty filename.

## How it works

`PACT_FILE_NAME` is derived from `PACT_ARCH` and `LIBC_SUFFIX`, and since `PACT_FFI_URL`, `LIBRARY_PATH`, and the version cache file are all derived from it, the download URL and cache invalidation automatically follow the selected variant — no other changes required.

## Testing

- Verified the musl asset names against the published `libpact_ffi-v0.4.27` GitHub release.
- glibc detection/path unchanged for existing Debian-based builds.

## Notes for consumers

When upgrading on Alpine CI, make sure the `_build`/`deps` cache from a previous glibc build is invalidated, and that compilation and runtime happen on the same libc (e.g. avoid compiling the NIF on a glibc stage and running on Alpine).
